### PR TITLE
Fix 404 and explain the need for setuid root upon Homebrew installation

### DIFF
--- a/kismet-git.rb
+++ b/kismet-git.rb
@@ -43,9 +43,9 @@ class KismetGit < Formula
       <<~EOS
         The macOS packet capture component of Kismet (kismet_cap_osx_corewlan_wifi) 
         needs to be suid-root in order to have the required permissions to reconfigure 
-        airport interfaces.  You can read more about installing as suid-root at 
+        airport interfaces.  You can read more about the need for root permissions at
 
-        https://www.kismetwireless.net/docs/readme/suid/#why-does-kismet-need-root
+        https://www.kismetwireless.net/docs/readme/datasources/wifi-macos/
 
         To change the permissions on the Kismet capture tool, either run the script 
         installed by Kismet via: 

--- a/kismet.rb
+++ b/kismet.rb
@@ -41,9 +41,9 @@ class Kismet < Formula
       <<~EOS
         The macOS packet capture component of Kismet (kismet_cap_osx_corewlan_wifi) 
         needs to be suid-root in order to have the required permissions to reconfigure 
-        airport interfaces.  You can read more about installing as suid-root at 
+        airport interfaces.  You can read more about the need for root permissions at
 
-        https://www.kismetwireless.net/docs/readme/suid/#why-does-kismet-need-root
+        https://www.kismetwireless.net/docs/readme/datasources/wifi-macos/
 
         To change the permissions on the Kismet capture tool, either run the script 
         installed by Kismet via: 


### PR DESCRIPTION
```sh
$ curl -v https://www.kismetwireless.net/docs/readme/suid/ 2>&1 | grep '^< HTTP/1.1 ' 
< HTTP/1.1 404 Not Found
```

The old link with explanation for setuid root permissions is now a 404. I did not dig through the documentation changelog to find where it went, but I've updated the formula post-installation notes to point to where in the documentation, suid-root is explained.

404 here: https://www.kismetwireless.net/docs/readme/suid/#why-does-kismet-need-root

Working link here: https://www.kismetwireless.net/docs/readme/datasources/wifi-macos/

I also slightly updated the text above to suit where the link points to.

Fixed in both formulae, btw only latest git HEAD version runs for me on arm64 macOS 14.6.1